### PR TITLE
always replace blackhole (xp)

### DIFF
--- a/app/db/db_functions.py
+++ b/app/db/db_functions.py
@@ -62,11 +62,8 @@ def directory_search():
             last_name = data[item]['last_name']
             first_name = data[item]['first_name']
             housing = data[item]['housing_building_room'].encode('utf-8')
-            # replacing blackhole emails with regular emails on non-prod env
-            if app.config['ENVIRON'] != 'prod':
-                email = data[item]['email'].replace('=bethel.edu@blackhole.bethel.edu', '@bethel.edu')
-            else:
-                email = data[item]['email']
+            # replacing blackhole emails with regular emails
+            email = data[item]['email'].replace('=bethel.edu@blackhole.bethel.edu', '@bethel.edu')
             username = data[item]['username']
             bu_po = data[item]['bu_po']
             bu_id = data[item]['bu_id']


### PR DESCRIPTION
## Description

The email search was broken on xp. The issue was because of the blackhole emails. This just ensures that we replace them

Fixes #71 

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

- tested this locally and on the server by doing a single email search

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
