### PR TITLE
Added the code to clear the cache

### DIFF
--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -1,10 +1,37 @@
+from functools import wraps
 import math
 
-from flask import render_template
+from flask import render_template, request, Response
 from fuzzywuzzy import fuzz
 
 from app import app
 from app.db.db_functions import directory_search
+
+
+def check_auth(username, password):
+    """This function is called to check if a username /
+    password combination is valid.
+    """
+    return username == app.config['CASCADE_LOGIN']['username'] and password == app.config['CASCADE_LOGIN']['password']
+
+
+def authenticate():
+    """Sends a 401 response that enables basic auth"""
+    return Response(
+        'Could not verify your access level for that URL.\n'
+        'You have to login with proper credentials', 401,
+        {'WWW-Authenticate': 'Basic realm="Login Required"'})
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+
+    return decorated
 
 
 class DirectoryController(object):

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -145,8 +145,8 @@ class View(FlaskView):
         return render_template('index.html', **locals())
 
     @requires_auth
-    @route('/public/clear-cache', methods=['GET'])
-    def clear_cache(self):
+    @route('/public/reset-cache', methods=['GET'])
+    def reset_cache(self):
         reset_directory_data()
         return 'success'
 

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -9,8 +9,8 @@ from flask import json as fjson
 from flask_classy import FlaskView, route
 
 from app import app, sentry
-from app.db.db_functions import portal_profile
-from app.directory_controller import DirectoryController
+from app.db.db_functions import portal_profile, reset_directory_data
+from app.directory_controller import DirectoryController, requires_auth
 
 
 class View(FlaskView):
@@ -143,6 +143,12 @@ class View(FlaskView):
     @route('/', methods=['GET'])
     def index(self):
         return render_template('index.html', **locals())
+
+    @requires_auth
+    @route('/public/clear-cache', methods=['GET'])
+    def clear_cache(self):
+        reset_directory_data()
+        return 'success'
 
     @route('/jira-endpoint', methods=['GET'])
     def jira_endpoint(self):

--- a/config.py.dist
+++ b/config.py.dist
@@ -8,6 +8,8 @@ LOGOUT_URL = ''
 
 ENVIRON = 'test'
 
+CASCADE_LOGIN = ''
+
 # TEST_USER = ''
 
 SENTRY_URL = ''


### PR DESCRIPTION
## Description

The directory has an issue with the current cacheing process. Every 4 hours a user has to front the 10s load time. What I chose to do to combat this is have it cache it manually for 24 hours (manually, meaning without memoize). We have to create a method to be the cacher, because we want to call cache.get() and cache.set() for the cache. Finally, we add a cron route that will reset the cache every 4 hours. This will make it seamless for the users, so the cache always exists.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- Config update needed
- Puppet update needed

## How Has This Been Tested?

- Tested locally making sure that the cache can be read, set, and cleared properly
- I'm currently testing on xp to run through the same tests, but I need to get the puppet branch up.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
