### PR TITLE
Add in logic to only allow students/staff/faculty to view the directory

### DIFF
--- a/app/views/home.py
+++ b/app/views/home.py
@@ -44,6 +44,14 @@ class View(FlaskView):
             if 'ID_view' not in session.keys():
                 get_id_view()
 
+            user_has_role = False
+            for role in session['roles']:
+                if 'STUDENT' in role or 'STAFF' in role or 'FACULTY' in role:
+                    user_has_role = True
+
+            if user_has_role == False:
+                return abort(403)
+
             log_user(session['username'])
 
         def get_user():


### PR DESCRIPTION
## Description

The directory is technically releasing information that only students/staff/faculty need access to. This PR is giving a 403 for any user who doesn't have one of those roles.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- I tested locally using a user who has these roles and a user who doesn't have these roles. It triggers the 403 as expected. I had to clear the session to properly see the user update successfully.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
