### PR TITLE
Add in reordering for roles

### DIFF
--- a/app/db/db_functions.py
+++ b/app/db/db_functions.py
@@ -99,6 +99,7 @@ def get_directory_data():
             class_standing = data[item]['stu_class']
 
             # the next ones potentially have multiple, split by a '|'
+            # this snippet could be moved into derek's script on IS's side.
             bu_role_list = get_splits(data[item]['bu_role'])
             bu_role_sort_key = {
                 "Staff":            1,

--- a/app/db/db_functions.py
+++ b/app/db/db_functions.py
@@ -99,6 +99,8 @@ def get_directory_data():
             class_standing = data[item]['stu_class']
 
             # the next ones potentially have multiple, split by a '|'
+
+            # ensure the order for those who have multiple roles.
             # this snippet could be moved into derek's script on IS's side.
             bu_role_list = get_splits(data[item]['bu_role'])
             bu_role_sort_key = {

--- a/app/db/db_functions.py
+++ b/app/db/db_functions.py
@@ -99,7 +99,15 @@ def get_directory_data():
             class_standing = data[item]['stu_class']
 
             # the next ones potentially have multiple, split by a '|'
-            bu_role = get_splits(data[item]['bu_role'])
+            bu_role_list = get_splits(data[item]['bu_role'])
+            bu_role_sort_key = {
+                "Staff":            1,
+                "Faculty":          2,
+                "Sponsored Staff":  3,
+                "Student":          4
+            }
+            bu_role_data = sorted(bu_role_list, key=lambda x: bu_role_sort_key[x])
+            bu_role = bu_role_data
             department = get_splits(data[item]['dept'])
             major = get_splits(data[item]['stu_majr'])
             minor = get_splits(data[item]['stu_minr'])


### PR DESCRIPTION
## Description

Derek noticed that it can be confusing for staff who are almost students. An example is Brooke - she is both staff and student, but her main role is actually Student. This snippet ensures the ordering of Staff, Sponsored Staff, Faculty, Student, if a user has multiple roles.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- I tested locally as its another very small change. It appears to work great after running through a handful of tests.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
