### PR TITLE
add phone search to directory

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,12 +38,54 @@ from app.db.db_functions import departments
 
 
 # https://stackoverflow.com/questions/919056/case-insensitive-replace
-def ireplace(string, findtxt):
+def ireplace(string, findtxt, phone=False):
     try:
         # find the start of the new string
-        index_l = string.lower().index(findtxt.lower())
-        # get the string with the correct capitalization
-        replacetxt = string[index_l:index_l + len(findtxt)]
+        index_l = string.replace('.', '').lower().index(findtxt.lower())
+
+        # if we are highlighting a phone number we need special logic
+        if phone:
+            try:
+                # make sure this is a number
+                int(string.replace('.', ''))
+                # get the index of our matching key
+                index_l = string.replace('.', '').lower().index(findtxt.lower())
+                findtxt_len = len(findtxt)
+
+                count = string.count('.', index_l, findtxt_len + 1)
+                # if index_l > 3:
+                #     index_l += 1 + count
+                # findtxt_len += count
+
+                # Do some logic to account for the '.'s in the number
+                if index_l < 3:
+                    findtxt_len += count
+                elif 2 < index_l < 6:
+                    index_l += 1
+                    findtxt_len += 1
+                elif index_l > 5:
+                    index_l += 2
+                    findtxt_len += 2
+
+                replacetxt = string[index_l:index_l + findtxt_len]
+
+                # pull off extra numbers that sometimes occur
+                if '.' not in replacetxt and len(replacetxt) > 3 and len(replacetxt) != len(findtxt):
+                    replacetxt = replacetxt[:-1]
+
+                # pull off rogue '.'s
+                if '.' in replacetxt:
+                    if replacetxt.index('.') == 0:
+                        replacetxt = replacetxt[1:]
+                    if replacetxt.index('.') == len(replacetxt) - 1:
+                        replacetxt = replacetxt[:-1]
+                    else:
+                        findtxt = replacetxt
+            except:
+                pass
+        else:
+            replacetxt = string[index_l:index_l + len(findtxt)]
+
         # add in the span to color it properly
         replacetxt = '<span class="search-match-highlight">%s</span>' % replacetxt
     except ValueError:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,6 +55,7 @@ def ireplace(string, findtxt):
 # try just looping over it manually
 # might be super slow, so just do a quick prototype
 
+
 # Shows the year for the template
 app.jinja_env.globals.update(now=datetime.datetime.now())
 app.jinja_env.globals.update(ireplace=ireplace)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -92,7 +92,9 @@ def ireplace(string, findtxt, phone=False):
         return string
 
     # keep capitalizations, if necessary
-    return replacetxt.join(re.compile(findtxt, flags=re.I).split(string, 1))
+    if findtxt:
+      return replacetxt.join(re.compile(findtxt, flags=re.I).split(string, 1))
+    return string
 
 # try just looping over it manually
 # might be super slow, so just do a quick prototype

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,48 +38,47 @@ from app.db.db_functions import departments
 
 
 # https://stackoverflow.com/questions/919056/case-insensitive-replace
-def ireplace(string, findtxt, phone=False):
+def ireplace(string, findtxt):
     try:
         # find the start of the new string
         index_l = string.replace('.', '').lower().index(findtxt.lower())
 
         # if we are highlighting a phone number we need special logic
-        if phone:
-            try:
-                # make sure this is a number
-                int(string.replace('.', ''))
-                # get the index of our matching key
-                index_l = string.replace('.', '').lower().index(findtxt.lower())
-                findtxt_len = len(findtxt)
+        try:
+            # make sure this is a number
+            int(string.replace('.', ''))
+            # get the index of our matching key
+            index_l = string.replace('.', '').lower().index(findtxt.lower())
+            findtxt_len = len(findtxt)
 
-                count = string.count('.', index_l, findtxt_len + 1)
+            count = string.count('.', index_l, findtxt_len + 1)
 
-                # Do some logic to account for the '.'s in the number
-                if index_l < 3:
-                    findtxt_len += count
-                elif 2 < index_l < 6:
-                    index_l += 1
-                    findtxt_len += 1
-                elif index_l > 5:
-                    index_l += 2
-                    findtxt_len += 2
+            # Do some logic to account for the '.'s in the number
+            if index_l < 3:
+                findtxt_len += count
+            elif 2 < index_l < 6:
+                index_l += 1
+                findtxt_len += 1
+            elif index_l > 5:
+                index_l += 2
+                findtxt_len += 2
 
-                replacetxt = string[index_l:index_l + findtxt_len]
+            replacetxt = string[index_l:index_l + findtxt_len]
 
-                # pull off extra numbers that sometimes occur
-                if '.' not in replacetxt and len(replacetxt) > 3 and len(replacetxt) != len(findtxt):
+            # pull off extra numbers that sometimes occur
+            if '.' not in replacetxt and len(replacetxt) > 3 and len(replacetxt) != len(findtxt):
+                replacetxt = replacetxt[:-1]
+
+            # pull off rogue '.'s
+            if '.' in replacetxt:
+                if replacetxt.index('.') == 0:
+                    replacetxt = replacetxt[1:]
+                if replacetxt.index('.') == len(replacetxt) - 1:
                     replacetxt = replacetxt[:-1]
-
-                # pull off rogue '.'s
-                if '.' in replacetxt:
-                    if replacetxt.index('.') == 0:
-                        replacetxt = replacetxt[1:]
-                    if replacetxt.index('.') == len(replacetxt) - 1:
-                        replacetxt = replacetxt[:-1]
-                    else:
-                        findtxt = replacetxt
-            except:
-                pass
+                else:
+                    findtxt = replacetxt
+        except:
+            pass
         else:
             replacetxt = string[index_l:index_l + len(findtxt)]
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,9 +53,6 @@ def ireplace(string, findtxt, phone=False):
                 findtxt_len = len(findtxt)
 
                 count = string.count('.', index_l, findtxt_len + 1)
-                # if index_l > 3:
-                #     index_l += 1 + count
-                # findtxt_len += count
 
                 # Do some logic to account for the '.'s in the number
                 if index_l < 3:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,54 +43,32 @@ def ireplace(string, findtxt):
         # find the start of the new string
         index_l = string.replace('.', '').lower().index(findtxt.lower())
 
-        # if we are highlighting a phone number we need special logic
+        findtxt_len = len(findtxt)
+
+        # Check if the string is a number or not
+        number = False
         try:
-            # make sure this is a number
             int(string.replace('.', ''))
-            # get the index of our matching key
-            index_l = string.replace('.', '').lower().index(findtxt.lower())
-            findtxt_len = len(findtxt)
-
-            count = string.count('.', index_l, findtxt_len + 1)
-
-            # Do some logic to account for the '.'s in the number
-            if index_l < 3:
-                findtxt_len += count
-            elif 2 < index_l < 6:
-                index_l += 1
-                findtxt_len += 1
-            elif index_l > 5:
-                index_l += 2
+            if findtxt:
+                # if it is a number and we are searching for something then increase length by 2 to account for the
+                # dividing characters (2 .'s)
                 findtxt_len += 2
-
-            replacetxt = string[index_l:index_l + findtxt_len]
-
-            # pull off extra numbers that sometimes occur
-            if '.' not in replacetxt and len(replacetxt) > 3 and len(replacetxt) != len(findtxt):
-                replacetxt = replacetxt[:-1]
-
-            # pull off rogue '.'s
-            if '.' in replacetxt:
-                if replacetxt.index('.') == 0:
-                    replacetxt = replacetxt[1:]
-                if replacetxt.index('.') == len(replacetxt) - 1:
-                    replacetxt = replacetxt[:-1]
-                else:
-                    findtxt = replacetxt
+                number = True
         except:
             pass
-        else:
-            replacetxt = string[index_l:index_l + len(findtxt)]
+
+        replacetxt = string[index_l:index_l + findtxt_len]
 
         # add in the span to color it properly
         replacetxt = '<span class="search-match-highlight">%s</span>' % replacetxt
     except ValueError:
         return string
 
+    # If it is a number then just return the replace span
+    if number:
+        return replacetxt
     # keep capitalizations, if necessary
-    if findtxt:
-      return replacetxt.join(re.compile(findtxt, flags=re.I).split(string, 1))
-    return string
+    return replacetxt.join(re.compile(findtxt, flags=re.I).split(string, 1))
 
 # try just looping over it manually
 # might be super slow, so just do a quick prototype

--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -191,6 +191,25 @@ class DirectoryController(object):
             'total_pages': math.ceil(len(result)/20)
         }
 
+    def phone_search(self, data, viewing_role):
+        people = directory_search()
+        result = []
+        data_phone = data['phone_number'].replace('-', '').replace('.', '')
+        search_type = ['Phone Number: {}'.format(data_phone)]
+
+        if data_phone != '':
+            for row in people:
+                if self.match_option(row, viewing_role):
+                    if data_phone in row['phone'].replace('.', ''):
+                        result.append(row)
+            result.sort(key=lambda i: i['last_name'])
+
+        return {
+            'results': result,
+            'search_type': search_type,
+            'total_pages': math.ceil(len(result)/20)
+        }
+
     def get_viewing_role(self, data):
         if data.get('faculty_or_staff') == 'true' and data.get('student') == 'true':
             return 'both'  # showing all results

--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -194,14 +194,15 @@ class DirectoryController(object):
     def phone_search(self, data, viewing_role):
         people = directory_search()
         result = []
-        data_phone = data['phone_number']\
+        data['phone_number'] = data['phone_number']\
             .replace('-', '').replace('.', '').replace(' ', '').replace('(', '').replace(')', '')
-        search_type = ['Phone Number: {}'.format(data_phone)]
+        search_type = ['Phone Number: {}'.format(data['phone_number'])]
 
-        if data_phone != '':
+        if data['phone_number'] != '':
             for row in people:
                 if self.match_option(row, viewing_role):
-                    if data_phone in row['phone'].replace('.', ''):
+                    row_phone = row['phone'].replace('.', '')
+                    if data['phone_number'] in row['phone'].replace('.', ''):
                         result.append(row)
             result.sort(key=lambda i: i['last_name'])
 

--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -202,7 +202,7 @@ class DirectoryController(object):
             for row in people:
                 if self.match_option(row, viewing_role):
                     row_phone = row['phone'].replace('.', '')
-                    if data['phone_number'] in row['phone'].replace('.', ''):
+                    if data['phone_number'] == row['phone'].replace('.', ''):
                         result.append(row)
             result.sort(key=lambda i: i['last_name'])
 

--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -194,7 +194,8 @@ class DirectoryController(object):
     def phone_search(self, data, viewing_role):
         people = directory_search()
         result = []
-        data_phone = data['phone_number'].replace('-', '').replace('.', '')
+        data_phone = data['phone_number']\
+            .replace('-', '').replace('.', '').replace(' ', '').replace('(', '').replace(')', '')
         search_type = ['Phone Number: {}'.format(data_phone)]
 
         if data_phone != '':

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,6 +20,7 @@
                         {% if session['ID_view'] %}
                         <li>ID</li>
                         {% endif %}
+                        <li>Phone Number</li>
                     </ul>
 
                     {% if 'FACULTY' in session['roles'] or 'STUDENT' in session['roles'] %}

--- a/app/templates/modules/search-form.html
+++ b/app/templates/modules/search-form.html
@@ -74,6 +74,11 @@
                             </div>
                         </div>
                         {% endif %}
+                        <div class="form-group form-row">
+                            <div class="col">
+                                <input type="tel" maxlength="12" class="form-control" id="phone_number" name="phone_number" placeholder="Phone Number">
+                            </div>
+                        </div>
 
                     </div>
                 </div>

--- a/app/templates/modules/search-form.html
+++ b/app/templates/modules/search-form.html
@@ -76,7 +76,8 @@
                         {% endif %}
                         <div class="form-group form-row">
                             <div class="col">
-                                <input type="tel" maxlength="12" class="form-control" id="phone_number" name="phone_number" placeholder="Phone Number">
+                                <input type="tel" minlength="10" maxlength="12" class="form-control" id="phone_number"
+                                       name="phone_number" placeholder="Phone Number">
                             </div>
                         </div>
 

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -276,7 +276,7 @@
                                     </div>
                                     <div class="col">
                                         {% if row_phone != '' %}
-                                            {{ ireplace(row['phone'], data['phone_number'], True)|safe }}
+                                            {{ ireplace(row['phone'], data['phone_number'])|safe }}
                                         {% else %}
                                             <p class="mb-0">{{ row['phone'] }}</p>
                                         {% endif %}

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -103,6 +103,7 @@
                                     </div>
                                 </div>
                             {% endif %}
+
                         {# TODO: We removed UDCID and ID on 2/20/2020, due to ferpa concerns. It might come back, but
                                     for now it is removed until we address this issue again :( #}
 {#                            {% if session['ID_view'] == True and (row['id'] != '' or row['udc'] != '') %}#}
@@ -274,7 +275,11 @@
                                         <p class="mb-0 font-weight-bold">Phone</p>
                                     </div>
                                     <div class="col">
-                                        <p class="mb-0">{{ row['phone'] }}</p>
+                                        {% if row_phone != '' %}
+                                            {{ ireplace(row['phone'], data['phone_number'], True)|safe }}
+                                        {% else %}
+                                            <p class="mb-0">{{ row['phone'] }}</p>
+                                        {% endif %}
                                     </div>
                                 </div>
                             {% endif %}

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -185,6 +185,8 @@ class View(FlaskView):
             results_data = self.base.email_search(data, viewing_role)
         elif data.get('bu_id', '') != '':
             results_data = self.base.id_search(data, viewing_role)
+        elif data.get('phone_number', '') != '':
+            results_data = self.base.phone_search(data, viewing_role)
         else:
             results_data = {}
 


### PR DESCRIPTION
## Description

Add phone search to directory under the "Advanced Search" dropdown. 

This search is visible for everyone since everyone can already see phone numbers. 

- It matches any subset of a phone number (eg. 2930 matches [293-0xx-xxxx, xxx-xxx-2930, xx2-930-xxxx, etc]) or any complete number (eg. 293-0293-0293 matches 293-0293-0293). 

- No fuzzy searching occurs currently (eg 2930 doesn't match 293-1xx-xxxx).

Fixes #90 

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Locally I looked up phone numbers and got users with those phone numbers

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)