### PR TITLE
add in id that you search

### DIFF
--- a/app/directory_controller.py
+++ b/app/directory_controller.py
@@ -174,7 +174,7 @@ class DirectoryController(object):
     def id_search(self, data, viewing_role):
         people = directory_search()
         result = []
-        search_type = ['ID']
+        search_type = ['ID: {}'.format(data['bu_id'])]
 
         if data['bu_id'] != '':
             for row in people:


### PR DESCRIPTION
## Description

I noticed that we don't display the searched ID. This PR is super small and adds in the formatting.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- super small, tested briefly locally

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)